### PR TITLE
Remediate high vulnerabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest
+FROM alpine:3.3
 
 MAINTAINER Maksym Nebot <maksym.nebot@accenture.com>
 


### PR DESCRIPTION
There are 96 high vulnerabilities on the current accenture/adop-ldap-phpadmin:latest image.
![image](https://user-images.githubusercontent.com/20415900/51523499-bee9c680-1e66-11e9-8aca-bdb615c42c58.png)

Updated alpine version to use specific version instead of latest to be able to build a new image. Newly built image doesn't have High vulnerability.
![image](https://user-images.githubusercontent.com/20415900/51523612-0bcd9d00-1e67-11e9-941f-24e03ab8d04f.png)